### PR TITLE
Separate Libraries & Fix importing

### DIFF
--- a/contracts/logic/AssetBond.sol
+++ b/contracts/logic/AssetBond.sol
@@ -42,7 +42,7 @@ library AssetBond {
   uint256 constant PRODUCT_NUMBER_START = 180;
 
   function parseAssetBondId(uint256 tokenId)
-    internal
+    external
     pure
     returns (DataStruct.AssetBondIdData memory)
   {
@@ -68,7 +68,7 @@ library AssetBond {
   }
 
   function getAssetBondDebtData(DataStruct.AssetBondData memory assetBondData)
-    internal
+    external
     view
     returns (uint256, uint256)
   {
@@ -84,6 +84,26 @@ library AssetBond {
     ).rayMul(assetBondData.principal);
 
     uint256 feeOnCollateralServiceProvider = calculateFeeOnRepayment(
+      assetBondData,
+      block.timestamp
+    );
+
+    return (accruedDebtOnMoneyPool, feeOnCollateralServiceProvider);
+  }
+
+  function getAssetBondLiquidationData(DataStruct.AssetBondData memory assetBondData)
+    external
+    view
+    returns (uint256, uint256)
+  {
+    uint256 accruedDebtOnMoneyPool = Math
+    .calculateCompoundedInterest(
+      assetBondData.interestRate,
+      assetBondData.collateralizeTimestamp,
+      block.timestamp
+    ).rayMul(assetBondData.principal);
+
+    uint256 feeOnCollateralServiceProvider = calculateDebtAmountToLiquidation(
       assetBondData,
       block.timestamp
     );
@@ -170,26 +190,6 @@ library AssetBond {
       vars.thirdTermRate;
 
     return assetBondData.principal.rayMul(vars.totalRate) - assetBondData.principal;
-  }
-
-  function getAssetBondLiquidationData(DataStruct.AssetBondData memory assetBondData)
-    internal
-    view
-    returns (uint256, uint256)
-  {
-    uint256 accruedDebtOnMoneyPool = Math
-    .calculateCompoundedInterest(
-      assetBondData.interestRate,
-      assetBondData.collateralizeTimestamp,
-      block.timestamp
-    ).rayMul(assetBondData.principal);
-
-    uint256 feeOnCollateralServiceProvider = calculateDebtAmountToLiquidation(
-      assetBondData,
-      block.timestamp
-    );
-
-    return (accruedDebtOnMoneyPool, feeOnCollateralServiceProvider);
   }
 
   struct CalculateDebtAmountToLiquidationLocalVars {

--- a/contracts/logic/Validation.sol
+++ b/contracts/logic/Validation.sol
@@ -17,7 +17,7 @@ library Validation {
    * @param reserve The reserve object
    * @param amount Deposit amount
    **/
-  function validateDeposit(DataStruct.ReserveData storage reserve, uint256 amount) internal view {
+  function validateDeposit(DataStruct.ReserveData storage reserve, uint256 amount) external view {
     if (amount == 0) revert MoneyPoolErrors.InvalidAmount(amount);
     if (reserve.isPaused == true) revert MoneyPoolErrors.ReservePaused();
     if (reserve.isActivated == false) revert MoneyPoolErrors.ReserveInactivated();
@@ -36,7 +36,7 @@ library Validation {
     address asset,
     uint256 amount,
     uint256 userLTokenBalance
-  ) internal view {
+  ) external view {
     if (amount == 0) revert MoneyPoolErrors.InvalidAmount(amount);
     if (reserve.isPaused == true) revert MoneyPoolErrors.ReservePaused();
     if (reserve.isActivated == false) revert MoneyPoolErrors.ReserveInactivated();
@@ -52,7 +52,7 @@ library Validation {
     DataStruct.AssetBondData memory assetBond,
     address asset,
     uint256 borrowAmount
-  ) internal view {
+  ) external view {
     if (reserve.isPaused == true) revert MoneyPoolErrors.ReservePaused();
     if (reserve.isActivated == false) revert MoneyPoolErrors.ReserveInactivated();
 
@@ -78,7 +78,7 @@ library Validation {
   function validateRepay(
     DataStruct.ReserveData storage reserve,
     DataStruct.AssetBondData memory assetBond
-  ) internal view {
+  ) external view {
     if (reserve.isActivated == false) revert MoneyPoolErrors.ReserveInactivated();
     if (block.timestamp >= assetBond.liquidationTimestamp) revert MoneyPoolErrors.LoanExpired();
     if (
@@ -93,19 +93,19 @@ library Validation {
   function validateLiquidation(
     DataStruct.ReserveData storage reserve,
     DataStruct.AssetBondData memory assetBond
-  ) internal view {
+  ) external view {
     if (reserve.isActivated == false) revert MoneyPoolErrors.ReserveInactivated();
     if (assetBond.state != DataStruct.AssetBondState.LIQUIDATED)
       revert MoneyPoolErrors.OnlyNotPerformedAssetBondLiquidatable(uint256(assetBond.state));
   }
 
-  function validateSignAssetBond(DataStruct.AssetBondData storage assetBond) internal view {
+  function validateSignAssetBond(DataStruct.AssetBondData storage assetBond) external view {
     if (assetBond.state != DataStruct.AssetBondState.SETTLED)
       revert TokenizerErrors.OnlySettledTokenSignAllowed();
     if (assetBond.signer != msg.sender) revert TokenizerErrors.OnlyDesignatedSignerAllowed();
   }
 
-  function validateSettleAssetBond(DataStruct.AssetBondData memory assetBond) internal view {
+  function validateSettleAssetBond(DataStruct.AssetBondData memory assetBond) external view {
     if (block.timestamp >= assetBond.loanStartTimestamp)
       revert TokenizerErrors.SettledLoanStartTimestampInvalid();
     if (assetBond.loanStartTimestamp == assetBond.maturityTimestamp)

--- a/deploy/mainnet.ts
+++ b/deploy/mainnet.ts
@@ -7,7 +7,7 @@ import {
 } from '../test/utils/testData';
 import { getContractAt } from 'hardhat-deploy-ethers/dist/src/helpers';
 import { MoneyPool } from '../typechain';
-import { getDai, getElyfi, getElysia } from './utils/dependencies';
+import { getAssetBond, getDai, getElyfi, getElysia, getValidation } from './utils/dependencies';
 
 export enum ELYFIContractType {
   CONNECTOR,
@@ -26,6 +26,10 @@ const deployMainnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
 
   const testIncentiveAsset = await getElyfi(hre, deployer);
 
+  const validation = await getValidation(hre);
+
+  const assetBond = await getAssetBond(hre);
+
   const connector = await deploy('Connector', {
     from: deployer,
     log: true,
@@ -35,6 +39,10 @@ const deployMainnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
     from: deployer,
     args: ['16', connector.address],
     log: true,
+    libraries: {
+      Validation: validation.address,
+      AssetBond: assetBond.address,
+    },
   });
 
   const incentivePool = await deploy('IncentivePool', {
@@ -69,6 +77,10 @@ const deployMainnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
     from: deployer,
     args: [connector.address, moneyPool.address, 'testTokenizer', 'T'],
     log: true,
+    libraries: {
+      Validation: validation.address,
+      AssetBond: assetBond.address,
+    },
   });
 
   const dataPipeline = await deploy('DataPipeline', {

--- a/deploy/testnet.ts
+++ b/deploy/testnet.ts
@@ -6,8 +6,8 @@ import {
   testReserveData,
 } from '../test/utils/testData';
 import { getContractAt } from 'hardhat-deploy-ethers/dist/src/helpers';
-import { ERC20Test, MoneyPool } from '../typechain';
-import { getDai, getElyfi } from './utils/dependencies';
+import { MoneyPool } from '../typechain';
+import { getAssetBond, getDai, getElyfi, getValidation } from './utils/dependencies';
 import { ethers } from 'hardhat';
 
 export enum ELYFIContractType {
@@ -26,6 +26,10 @@ const deployTestnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
 
   const testIncentiveAsset = await getElyfi(hre, deployer);
 
+  const validation = await getValidation(hre);
+
+  const assetBond = await getAssetBond(hre);
+
   const connector = await deploy('Connector', {
     from: deployer,
     log: true,
@@ -35,6 +39,10 @@ const deployTestnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
     from: deployer,
     args: ['16', connector.address],
     log: true,
+    libraries: {
+      Validation: validation.address,
+      AssetBond: assetBond.address,
+    },
   });
 
   const incentivePool = await deploy('IncentivePool', {
@@ -76,6 +84,10 @@ const deployTestnet: DeployFunction = async function (hre: HardhatRuntimeEnviron
     from: deployer,
     args: [connector.address, moneyPool.address, 'testTokenizer', 'T'],
     log: true,
+    libraries: {
+      Validation: validation.address,
+      AssetBond: assetBond.address,
+    },
   });
 
   const dataPipeline = await deploy('DataPipeline', {

--- a/deploy/utils/dependencies.ts
+++ b/deploy/utils/dependencies.ts
@@ -5,6 +5,42 @@ import ELToken_ABI from '../../dependencies/ELToken.json';
 import Dai_ABI from '../../dependencies/Dai.json';
 import Elyfi_ABI from '../../dependencies/Elyfi.json';
 
+export const getValidation = async (hre: HardhatRuntimeEnvironment): Promise<Contract> => {
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy } = hre.deployments;
+  let validation: Contract;
+
+  const validationLocalDeploy = await deploy('Validation', {
+    from: deployer,
+    log: true,
+  });
+
+  validation = await hre.ethers.getContractAt(
+    validationLocalDeploy.abi,
+    validationLocalDeploy.address
+  );
+
+  return validation;
+};
+
+export const getAssetBond = async (hre: HardhatRuntimeEnvironment): Promise<Contract> => {
+  const { deployer } = await hre.getNamedAccounts();
+  const { deploy } = hre.deployments;
+  let assetBond: Contract;
+
+  const assetBondLocalDeploy = await deploy('AssetBond', {
+    from: deployer,
+    log: true,
+  });
+
+  assetBond = await hre.ethers.getContractAt(
+    assetBondLocalDeploy.abi,
+    assetBondLocalDeploy.address
+  );
+
+  return assetBond;
+};
+
 export const getElysia = async (
   hre: HardhatRuntimeEnvironment,
   signer: string

--- a/tasks/testnet/tokenizer.ts
+++ b/tasks/testnet/tokenizer.ts
@@ -2,7 +2,7 @@ import { task } from 'hardhat/config';
 import ElyfiContracts from '../../test/types/ElyfiContracts';
 import getDeployedContracts from '../../test/utils/getDeployedContracts';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
-import { testAssetBondData } from '../../test/utils/testData';
+import { testAssetBond } from '../../test/utils/testData';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
 import assetBondIdData from '../../misc/assetBond/assetBondIdDataExample.json';
 import { tokenIdGenerator } from '../../misc/assetBond/generator';
@@ -219,15 +219,15 @@ task('testnet:createSignedAssetBondForTest', 'Create signed asset bond for only 
       borrower.address,
       signer.address,
       tokenId,
-      testAssetBondData.principal,
-      testAssetBondData.couponRate,
-      testAssetBondData.delinquencyRate,
-      testAssetBondData.debtCeiling,
-      testAssetBondData.loanDuration,
+      testAssetBond.principal,
+      testAssetBond.couponRate,
+      testAssetBond.delinquencyRate,
+      testAssetBond.debtCeiling,
+      testAssetBond.loanDuration,
       loanStartDate.getUTCFullYear(),
       loanStartDate.getUTCMonth() + 1, //javascript UTC should be +1
       loanStartDate.getUTCDate(),
-      testAssetBondData.ipfsHash
+      testAssetBond.ipfsHash
     );
     await settleTx.wait();
     console.log(`The collateral service provider settled asset bond which id is ${args.bond}`);
@@ -269,15 +269,15 @@ task('testnet:settleAssetBond', 'settle empty asset bond')
         borrower.address,
         signer.address,
         tokenId,
-        testAssetBondData.principal,
-        testAssetBondData.couponRate,
-        testAssetBondData.delinquencyRate,
-        testAssetBondData.debtCeiling,
-        testAssetBondData.loanDuration,
-        testAssetBondData.loanStartTimeYear,
-        testAssetBondData.loanStartTimeMonth,
-        testAssetBondData.loanStartTimeDay,
-        testAssetBondData.ipfsHash
+        testAssetBond.principal,
+        testAssetBond.couponRate,
+        testAssetBond.delinquencyRate,
+        testAssetBond.debtCeiling,
+        testAssetBond.loanDuration,
+        testAssetBond.loanStartTimeYear,
+        testAssetBond.loanStartTimeMonth,
+        testAssetBond.loanStartTimeDay,
+        testAssetBond.ipfsHash
       );
 
     console.log(`The collateral service provider settles asset token which id is "${args.bond}"`);

--- a/test/assertions/equals.ts
+++ b/test/assertions/equals.ts
@@ -37,7 +37,6 @@ Assertion.addMethod('equalReserveData', function (expectedData: ReserveData) {
   const actualData = <ReserveData>this._obj;
 
   (Object.keys(actualData) as (keyof ReserveData)[]).forEach((key) => {
-    console.log(key, expectedData[key].toString());
     expect(expectedData[key]).to.eq(actualData[key]);
   });
 });
@@ -46,7 +45,6 @@ Assertion.addMethod('equalUserData', function (expectedData: UserData) {
   const actualData = <UserData>this._obj;
 
   (Object.keys(actualData) as (keyof UserData)[]).forEach((key) => {
-    console.log(key, expectedData[key].toString(), actualData[key].toString());
     expect(expectedData[key]).to.eq(actualData[key]);
   });
 });

--- a/test/contracts/Moneypool/borrow.test.ts
+++ b/test/contracts/Moneypool/borrow.test.ts
@@ -6,7 +6,7 @@ import takeDataSnapshot from '../../utils/takeDataSnapshot';
 import { RAY, SECONDSPERDAY } from '../../utils/constants';
 import loadFixture from '../../utils/loadFixture';
 import { settleAssetBond } from '../../utils/Helpers';
-import { testAssetBondData } from '../../utils/testData';
+import { testAssetBond } from '../../utils/testData';
 import {
   toTimestamp,
   advanceTimeTo,
@@ -21,6 +21,7 @@ import utilizedMoneypool from '../../fixtures/utilizedMoneypool';
 require('../../assertions/equals.ts');
 
 describe('MoneyPool.borrow', () => {
+  const testAssetBondData = { ...testAssetBond };
   let elyfiContracts: ElyfiContracts;
 
   const provider = waffle.provider;

--- a/test/contracts/Moneypool/deposit.test.ts
+++ b/test/contracts/Moneypool/deposit.test.ts
@@ -12,7 +12,7 @@ import { getTimestamp } from '../../utils/time';
 describe('MoneyPool.deposit', () => {
   let elyfiContracts: ElyfiContracts;
 
-  const [deployer, depositor] = waffle.provider.getWallets();
+  const [deployer, depositor, CSP, borrower, signer, otherCSP] = waffle.provider.getWallets();
 
   beforeEach(async () => {
     const fixture = await loadFixture(utilizedMoneypool);

--- a/test/contracts/Moneypool/repay.test.ts
+++ b/test/contracts/Moneypool/repay.test.ts
@@ -12,7 +12,7 @@ import loadFixture from '../../utils/loadFixture';
 import utilizedMoneypool from '../../fixtures/utilizedMoneypool';
 import { getAssetBondData, settleAssetBond } from '../../utils/Helpers';
 import { calculateAssetBondDebtData } from '../../utils/Math';
-import { testAssetBondData } from '../../utils/testData';
+import { testAssetBond } from '../../utils/testData';
 import {
   toTimestamp,
   advanceTimeTo,
@@ -26,6 +26,7 @@ require('../../assertions/equals.ts');
 describe('MoneyPool.repay', () => {
   let elyfiContracts: ElyfiContracts;
 
+  const testAssetBondData = { ...testAssetBond };
   const provider = waffle.provider;
   const [deployer, depositor, CSP, borrower, signer] = provider.getWallets();
 

--- a/test/contracts/Tokenizer/mint.test.ts
+++ b/test/contracts/Tokenizer/mint.test.ts
@@ -4,11 +4,12 @@ import { makeAllContracts } from '../../utils/makeContract';
 import { expect } from 'chai';
 import ElyfiContracts from '../../types/ElyfiContracts';
 import AssetBondState from '../../types/AssetBondState';
-import { testAssetBondData } from '../../utils/testData';
+import { testAssetBond } from '../../utils/testData';
 
 describe('Tokenizer.mint', () => {
   let elyfiContracts: ElyfiContracts;
 
+  const testAssetBondData = { ...testAssetBond };
   const provider = waffle.provider;
   const [deployer, depositor, CSP, borrower, signer, account] = provider.getWallets();
 

--- a/test/contracts/Tokenizer/settle.test.ts
+++ b/test/contracts/Tokenizer/settle.test.ts
@@ -7,11 +7,12 @@ import { settleAssetBond } from '../../utils/Helpers';
 import { SECONDSPERDAY } from '../../utils/constants';
 import AssetBondState from '../../types/AssetBondState';
 import { toTimestamp } from '../../utils/time';
-import { testAssetBondData } from '../../utils/testData';
+import { testAssetBond } from '../../utils/testData';
 
 describe('Tokenizer.settle', () => {
   let elyfiContracts: ElyfiContracts;
 
+  const testAssetBondData = { ...testAssetBond };
   const provider = waffle.provider;
   const [deployer, depositor, CSP, borrower, signer, account] = provider.getWallets();
 

--- a/test/contracts/Tokenizer/sign.test.ts
+++ b/test/contracts/Tokenizer/sign.test.ts
@@ -5,11 +5,12 @@ import { expect } from 'chai';
 import ElyfiContracts from '../../types/ElyfiContracts';
 import { settleAssetBond } from '../../utils/Helpers';
 import AssetBondState from '../../types/AssetBondState';
-import { testAssetBondData } from '../../utils/testData';
+import { testAssetBond } from '../../utils/testData';
 
 describe('Tokenizer.sign', () => {
   let elyfiContracts: ElyfiContracts;
 
+  const testAssetBondData = { ...testAssetBond };
   const provider = waffle.provider;
   const [deployer, depositor, CSP, borrower, signer, account] = provider.getWallets();
 

--- a/test/types/ElyfiLogics.ts
+++ b/test/types/ElyfiLogics.ts
@@ -1,0 +1,8 @@
+import { AssetBond, Validation } from '../../typechain';
+
+interface ElyfiLogics {
+  validation: Validation;
+  assetBond: AssetBond;
+}
+
+export default ElyfiLogics;

--- a/test/utils/testData.ts
+++ b/test/utils/testData.ts
@@ -23,7 +23,7 @@ export const testInterestModelParams: InterestModelParams = <InterestModelParams
   borrowRateMax: toRate(1),
 };
 
-export const testAssetBondData: AssetBondSettleData = <AssetBondSettleData>{
+export const testAssetBond: AssetBondSettleData = <AssetBondSettleData>{
   ...(<AssetBondSettleData>{}),
   borrower: '',
   signer: '',


### PR DESCRIPTION
* Seperate libraries : Since the size of the moneypool contract exceeds a limit to deploy on mainnet, the libraries, Validation, and AssetBond are separated. These libraries must be deployed and linked before the deployment of core components. 
Deploy script and test environments are also modified. 

* Fix error : Since the global test seed data has conflict in the solidity coverage runtime, so modified to copy it