### PR TITLE
Fix mainnet dai tokenizer address

### DIFF
--- a/deployments/mainnet/Tokenizer.json
+++ b/deployments/mainnet/Tokenizer.json
@@ -1,5 +1,5 @@
 {
-  "address": "0x68f69Ab21242e194ebd7534B598e26180dD92616",
+  "address": "0xc6701e7be98a79485364419961838eb141141aaf",
   "abi": [
     {
       "inputs": [


### PR DESCRIPTION
It was previously the usdt tokenizer address, so I fixed it with the dai tokenizer address in README.